### PR TITLE
Allow mixed case tags

### DIFF
--- a/src/bibtex.jl
+++ b/src/bibtex.jl
@@ -76,6 +76,7 @@ function make_bibtex_entry(
     if "eprint" ∈ keys(fields)
         fields["type"] = "eprint"
     end
+    fields = Dict(lowercase(k)=>v for (k,v) in fields) # lowercase tag names
     errors = check_entry(fields)
     if length(errors) > 0
         error("Entry $id is missing the " * foldl(((x, y) -> x * ", " * y), errors) * " field(s).")


### PR DESCRIPTION
[BibTex format](http://www.bibtex.org/Format/) allows any case in tag names, but the internal rules for entry fields are hard-coded in lower case which results in parsing errors when tags are in mixed case.

Forcing tag names internally into lowercase before verification fixes the issue.