### PR TITLE
Naive implementation of comparators for Date and Name

### DIFF
--- a/src/entry.jl
+++ b/src/entry.jl
@@ -297,21 +297,21 @@ function Entry(id::String, fields::Fields)
 end
 
 """
-    Base.isless(a::BibInternal.Date, b::Bibinternal.Date)
+    Base.isless(a::BibInternal.Date,b::BibInternal.Date)::Bool
 
-Function to check for `a < b` on `BibInternal.Date` data types. This function
-will throw an `ArgumentError` if the `year` is not parse able to `Int`. If it
-is not possible to parse `month` or `day` to `Int` those entries will be
-silently ignored for comparison.
+Function to check for `a < b` on `BibInternal.Date` data types.
+
+This function will throw an `ArgumentError` if the `year` can not parsed into
+`Int`. If it is not possible to parse `month` or `day` to `Int` those entries
+will be silently ignored for comparison.
 This function will not check if the date fields are given in a correct format
-those fields are parsed into and compared as `Int` (no checking if date format
-is correct!).
+all fields are parsed into and compared as `Int` (no checking if date format
+is correct or valid!).
 !!! danger "Note:"
     The silent ignoring of not parseable `month` or `day` fields will lead to
     misbehaviour if using comparators like `==` or `!==`!
 """
-function Base.isless(a::BibInternal.Date,
-                     b::BibInternal.Date)
+function Base.isless(a::BibInternal.Date,b::BibInternal.Date)::Bool
     numbers = "0123456789";
     not_valid_year = isempty(a.year) || isempty(b.year) ||
                      !issubset(a.year,numbers) || !issubset(b.year,numbers);
@@ -341,5 +341,34 @@ function Base.isless(a::BibInternal.Date,
         end
     else
         return (a_y < b_y);
+    end
+end
+
+"""
+    Base.isless(a::BibInternal.Name,b::BibInternal.Name)::Bool
+
+Function to check for `a < b` on `BibInternal.Name` data types.
+
+This function will check the fields `last`, `first` and `middle` in this order
+of priority. The other fields are ignored for now.
+The field comparsion is done by string comparsion no advanced alphabetizing
+rules are used for now.
+!!! danger "Note:"
+    The silent ignoring of the other fields might lead to misbehaviour if using
+    comparators like `==` or `!==`!
+"""
+function Base.isless(a::BibInternal.Name,b::BibInternal.Name)::Bool
+    if (a.last == b.last)
+        if (a.first == b.first)
+            if (a.middle == b.middle)
+                return false;
+            else
+                return (a.middle < b.middle);
+            end
+        else
+            return (a.first < b.first);
+        end
+    else
+        return (a.last < b.last);
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,4 +2,32 @@ using BibInternal
 using Test
 
 # TODO: make error testing for new version
-@test true
+#@test true
+
+@testset "isless() for BibInternal.Date" begin
+
+    @test BibInternal.Date("","","2000") < BibInternal.Date("","","2001");
+    @test BibInternal.Date("","10","2000") < BibInternal.Date("","11","2000");
+    @test BibInternal.Date("5","01","2000") < BibInternal.Date("15","01","2000");
+
+    @test BibInternal.Date("","","1970") > BibInternal.Date("","","1969");
+    @test BibInternal.Date("","7","1970") > BibInternal.Date("","6","1970");
+    @test BibInternal.Date("7","7","1970") > BibInternal.Date("6","7","1970");
+
+    @test BibInternal.Date("","","1805") == BibInternal.Date("","","1805");
+    @test BibInternal.Date("","4","1805") == BibInternal.Date("","4","1805");
+    @test BibInternal.Date("3","4","1805") == BibInternal.Date("3","4","1805");
+
+    @test BibInternal.Date("","","1805") !== BibInternal.Date("","","1905");
+    @test BibInternal.Date("","4","1805") !== BibInternal.Date("","5","1805");
+    @test BibInternal.Date("3","4","1805") !== BibInternal.Date("4","4","1805");
+
+    @test_skip BibInternal.Date("","May","1805") == BibInternal.Date("","5","1805");
+    @test_skip BibInternal.Date("1th","5","1805") !== BibInternal.Date("1","5","1805");
+
+    @test_throws ArgumentError BibInternal.Date("","","1") < BibInternal.Date("","","2000a");
+    @test_throws ArgumentError BibInternal.Date("","","1") < BibInternal.Date("","","");
+    @test_throws ArgumentError BibInternal.Date("","","1") < BibInternal.Date("","","90ies");
+    @test_throws ArgumentError BibInternal.Date("","","40k") < BibInternal.Date("","","40000");
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,3 +31,21 @@ using Test
     @test_throws ArgumentError BibInternal.Date("","","40k") < BibInternal.Date("","","40000");
 
 end
+
+@testset "isless() for BibInternal.Name" begin
+    # TODO: consider testing for alphabetizing rules
+
+    @test BibInternal.Name("","Cow","","John","") < BibInternal.Name("","Doe","","John","");
+    @test BibInternal.Name("","Doe","","John","A.") < BibInternal.Name("","Doe","","John","B.");
+    @test BibInternal.Name("","Doe","","Bronn","") < BibInternal.Name("","Doe","","John","");
+    @test BibInternal.Name("","Bronn","","Would","") < BibInternal.Name("","Bronn","","Would","Not");
+
+    @test BibInternal.Name("","Doe","","John","") == BibInternal.Name("","Doe","","John","");
+    @test BibInternal.Name("","Doe","jun.","John","") == BibInternal.Name("","Doe","jun.","John","");
+    @test BibInternal.Name("","Doe","","John","E.") == BibInternal.Name("","Doe","","John","E.");
+
+    @test BibInternal.Name("","Doe","","Bronn","") !== BibInternal.Name("","Doe","","John","");
+    @test BibInternal.Name("","Doe","jun.","John","") !== BibInternal.Name("","Doe","sen.","John","");
+    @test BibInternal.Name("","Doe","","John","E.") !== BibInternal.Name("","Doe","","John","A.");
+
+end


### PR DESCRIPTION
https://github.com/Humans-of-Julia/Bibliography.jl/issues/17
Naive implementation of comparators for `BibInternal.Date` and `BibInternal.Name`.
With this the comparison of `BibInternal.Names` will be also automatically possible.

Naive because the correct ordering of Names is whole rabbit hole of its own see e.g. [#](https://www.isko.org/cyclo/alphabetization#5) & [##](https://en.wikipedia.org/wiki/Alphabetical_order).