### PR TITLE
Simplify `names`, handle empty strings correctly

### DIFF
--- a/src/entry.jl
+++ b/src/entry.jl
@@ -23,6 +23,8 @@ Names = Vector{Name}
 Decompose without ambiguities a name as `particle` (optional) `last`, `junior` (optional), `first` `middle` (optional) based on BibTeX possible input. As for BibTeX, the decomposition of a name in the form of `first` `last` is also possible, but ambiguities can occur.
 """
 function Name(str)
+    @assert !isempty(strip(str))  "Name must not be empty or consist of only whitespace"
+
     subnames = map(strip, split(str, r"[\n\r\t ]*,[\n\r\t ]*"; keepempty=false))
 
     # subnames containers
@@ -96,10 +98,7 @@ end
     names(str::String)
 Decompose into parts a list of names in BibTeX compatible format. That is names separated by `and`.
 """
-function names(str)
-    aux = split(str, r"[\n\r ]and[\n\r ]")
-    return map(x -> Name(String(x)), aux)
-end
+names(str) = map(Name, split(strip(str), r"\s+and\s+"; keepempty = false))
 
 """
     struct Access


### PR DESCRIPTION
An empty string, or a string consisting of only whitespace, should
result in an empty list of names; previously it resulted in a list
containing a single "empty" name.

Unfortunately, this change breaks Bibliography.jl. But see
<https://github.com/Humans-of-Julia/Bibliography.jl/pull/28>
for a corresponding fix there.