### PR TITLE
Simplify Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,4 +4,4 @@ authors = ["azzaare"]
 version = "0.3.0"
 
 [compat]
-julia = "1.4, 1.5, 1.6, 1.7"
+julia = "1.4"


### PR DESCRIPTION
Specifying `compat = "1.4"` is shorthand for `compat = "^1.4"` which in turn means "any 1.X version >= 1.4"