### PR TITLE
Fix small bug in `Name` junior parsing

### DIFF
--- a/src/entry.jl
+++ b/src/entry.jl
@@ -88,7 +88,9 @@ function Name(str)
             last = "$s " * last
         end
         particle = join(aux[1:mark_out], " ")
-        junior = subnames[2]
+        aux = subnames[2]
+        @assert length(aux) == 1  "malformed junior subname"
+        junior = aux[1]
         aux = subnames[end]  # First Second
         first = aux[1]
         middle = join(aux[2:end], " ")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,7 +50,7 @@ end
 
 end
 
-@testset "Name" begin
+@testset "junior parsing for BibInternal.Name" begin
     name = BibInternal.Name("Doe, Jr, Abe Brian")
     name_expected = BibInternal.Name("", "Doe", "Jr", "Abe", "Brian")
     @test name == name_expected
@@ -59,4 +59,10 @@ end
     name_expected = BibInternal.Name("", "Doe", "Jr.", "A.", "B.")
     @test name == name_expected
 
+    # If no comma is used between the last name and junior, the junior should be
+    # combined with the last name
+    # (https://nwalsh.com/tex/texhelp/bibtx-23.html).
+    name = BibInternal.Name("Doe Jr., A. B.")
+    name_expected = BibInternal.Name("", "Doe Jr.", "", "A.", "B.")
+    @test name == name_expected
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,3 +49,14 @@ end
     @test BibInternal.Name("","Doe","","John","E.") !== BibInternal.Name("","Doe","","John","A.");
 
 end
+
+@testset "Name" begin
+    name = BibInternal.Name("Doe, Jr, Abe Brian")
+    name_expected = BibInternal.Name("", "Doe", "Jr", "Abe", "Brian")
+    @test name == name_expected
+
+    name = BibInternal.Name("Doe, Jr., A. B.")
+    name_expected = BibInternal.Name("", "Doe", "Jr.", "A.", "B.")
+    @test name == name_expected
+
+end


### PR DESCRIPTION
I ran into this error when trying to parse a `Name` field with a junior:

```julia
julia> using BibInternal: Name

julia> Name("Doe, Jr., John")
ERROR: MethodError: Cannot `convert` an object of type Vector{SubString{String}} to an object of type String
Closest candidates are:
  convert(::Type{String}, ::String) at essentials.jl:210
  convert(::Type{T}, ::T) where T<:AbstractString at strings/basic.jl:231
  convert(::Type{T}, ::AbstractString) where T<:AbstractString at strings/basic.jl:232
  ...
Stacktrace:
 [1] Name(particle::String, last::SubString{String}, junior::Vector{SubString{String}}, first::SubString{String}, middle::String)
   @ BibInternal ~/Documents/LitMan.jl-dev/dev/LitMan.jl/dev/BibInternal/src/entry.jl:13
 [2] Name(str::String)
   @ BibInternal ~/Documents/LitMan.jl-dev/dev/LitMan.jl/dev/BibInternal/src/entry.jl:102
 [3] top-level scope
   @ REPL[18]:1

julia>
```

This PR should fix it, I think.