### PR TITLE
Bugfix for negative spaces in `space(field::Symbol)`

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -2,7 +2,7 @@
     space(field::Symbol)
 Return the amount of spaces needed to export entries, for instance to BibTeX format.
 """
-space(field) = maxfieldlength - length(string(field))
+space(field) = max(maxfieldlength - length(string(field)), 0)
 
 """
     get_delete!(fields::Fields, key::String)


### PR DESCRIPTION
Love Bibliography.jl, thanks for these packages!

I have bibtex files with some extra-long fields, for example
```
    @inproceedings{farassat_theoretical_analysis_linearized_acoustics_supersonic_propellers_1985,
     organization  = {NASA Langley Research Center},
     pages         = {15 p},
     distributionlimits = {Unclassified; Publicly available; Unlimited},
     booktitle     = {AGARD Aerodyn. and Acoustics of Propellers},
     author        = {Farassat, F.},
     month         = {02},
     source        = {NASA STI Program - NTRS},
     title         = {Theoretical analysis of linearized acoustics and aerodynamics of advanced supersonic propellers},
     doctype       = {Conference Paper},
     link          = {https://ntrs.nasa.gov/search.jsp?R=19860001689},
     ntrsdocid     = {19860001689},
     year          = {1985},
     rights        = {Copyright; Distribution within the U.S. granted by agreement},
     file          = {AGARDCP366:fulltext/farassat_theoretical_analysis_linearized_acoustics_supersonic_propellers_1985-AGARDCP366.pdf:application/pdf}
    }
```

When I try to parse that, I get an error:
```
ERROR: ArgumentError: can't repeat a string -5 times
Stacktrace:
 [1] repeat(s::String, r::Int64)
   @ Base ./strings/substring.jl:226
 [2] int_to_spaces
   @ ~/projects/LitMan.jl-dev/spaces_bug/dev/Bibliography/src/bibtex.jl:15 [inlined]
 [3] field_to_bibtex(key::String, value::String)
   @ Bibliography ~/projects/LitMan.jl-dev/spaces_bug/dev/Bibliography/src/bibtex.jl:27
 [4] export_bibtex(e::BibInternal.Entry)
   @ Bibliography ~/projects/LitMan.jl-dev/spaces_bug/dev/Bibliography/src/bibtex.jl:135
 [5] export_bibtex(bibliography::OrderedCollections.OrderedDict{String, BibInternal.Entry})
   @ Bibliography ~/projects/LitMan.jl-dev/spaces_bug/dev/Bibliography/src/bibtex.jl:149
 [6] doit()
   @ Main.Test1 ~/projects/LitMan.jl-dev/spaces_bug/test1.jl:29
 [7] top-level scope
   @ REPL[7]:1
```

The problem is that the `distributionlimits` field is longer than any of the standard fields in the BibTeX file format. This messes up the space offset calculation when writing out the file.

Here's the script I used to test this:
```julia
module Test1

using Bibliography
using BibParser

function doit()

    bibtex_str = """
    @inproceedings{farassat_theoretical_analysis_linearized_acoustics_supersonic_propellers_1985,
     organization  = {NASA Langley Research Center},
     pages         = {15 p},
     distributionlimits = {Unclassified; Publicly available; Unlimited},
     booktitle     = {AGARD Aerodyn. and Acoustics of Propellers},
     author        = {Farassat, F.},
     month         = {02},
     source        = {NASA STI Program - NTRS},
     title         = {Theoretical analysis of linearized acoustics and aerodynamics of advanced supersonic propellers},
     doctype       = {Conference Paper},
     link          = {https://ntrs.nasa.gov/search.jsp?R=19860001689},
     ntrsdocid     = {19860001689},
     year          = {1985},
     rights        = {Copyright; Distribution within the U.S. granted by agreement},
     file          = {AGARDCP366:fulltext/farassat_theoretical_analysis_linearized_acoustics_supersonic_propellers_1985-AGARDCP366.pdf:application/pdf},
     abstract      = {The derivation of a formula for prediction of the noise of supersonic propellers using time domain analysis is presented. This formula is a solution of the Ffowcs Williams-Hawkings equation and does not have the Doppler singularity of some other formulations. The result presented involves some surface integrals over the blade and line integrals over the leading and trailing edges. The blade geometry, motion and surface pressure are needed for noise calculation. To obtain the blade surface pressure, the observer is moved onto the blade surface and a linear singular integral equation is derived which can be solved numerically. Two examples of acoustic calculations using a computer program are currently under development.}
    }
    """

    db = BibParser.parse_entry(bibtex_str)
    export_bibtex(db)
end

end # module

```