### PR TITLE
Do not use "eprint" as a type

### DIFF
--- a/src/bibtex.jl
+++ b/src/bibtex.jl
@@ -80,7 +80,6 @@ Make an entry if the entry follows the BibTeX guidelines. Throw an error otherwi
 """
 function make_bibtex_entry(id, fields; check=:error)
     # @info id fields
-    "eprint" ∈ keys(fields) && (fields["_type"] = "eprint")
     fields = Dict(lowercase(k) => v for (k, v) in fields) # lowercase tag names
     errors = check_entry(fields, check, id)
     if length(errors) > 0 && check ∈ [:error, :warn]


### PR DESCRIPTION
Just removing the offending line doesn't break any tests in `BibInternal`.

I couldn't run the tests in the upstream `Bibliography.jl` (it's complaining about a `MethodError: no method matching String(::OrderedCollections.OrderedDict{String, BibInternal.Entry})`, even on `master`, not sure what that's about), so I don't know if this changed may require any modifications to `Bibliography`.

However, I did test the changed routine in `DocumenterCitations`, and it seems to work perfectly there.

Closes #22