### PR TITLE
Fix error in check_entry

### DIFF
--- a/src/bibtex.jl
+++ b/src/bibtex.jl
@@ -64,7 +64,10 @@ function check_entry(fields, check, id)
                 end
             end
             if !at_least_one
-                push!(errors, "{" * foldl((x, y) -> "$x≡$y", t_field; init="")[2:end] * "}")
+                s = foldl((x, y) -> "$x≡$y", t_field; init="")
+                # To remove the starting `≡`, we need `nextind` as it is a
+                # multibyte character
+                push!(errors, "{" * s[nextind(s, 1):end] * "}")
             end
         else
             get(fields, t_field, "") == "" && push!(errors, t_field)


### PR DESCRIPTION
I would guess this line is not covered by the test because it always produces a string with `≡` as first character so get `getindex` fails with `2` since it's in the middle of that multibyte character